### PR TITLE
fix: typo in Migration-Svelte-5

### DIFF
--- a/sites/docs/src/content/migration/svelte-5/index.md
+++ b/sites/docs/src/content/migration/svelte-5/index.md
@@ -37,7 +37,7 @@ Add the `registry` to the root object, and add `hooks` and `ui` keys under `alia
   "style": "default",
   "tailwind": {
     "config": "tailwind.config.js",
-    "css": "src\\app.pcss",
+    "css": "src/app.pcss",
     "baseColor": "zinc"
   },
   "aliases": {


### PR DESCRIPTION
# Summary

* replaced `\\` with `/` in code example under `components.json`. (see screenshot)

* on `https://next.shadcn-svelte.com/docs/migration/svelte-5`
* Shown on website: `"css": "src\app.pcss",` (should be '/')

<img width="774" alt="Screenshot 2024-12-19 at 5 05 51 PM" src="https://github.com/user-attachments/assets/782b2147-65a8-4956-8947-78602b5d20ec" />
